### PR TITLE
stop reading block at EOF

### DIFF
--- a/block.py
+++ b/block.py
@@ -28,6 +28,9 @@ class Block:
 		if self.hasLength(blockchain, 8):	
 			self.magicNum = uint4(blockchain)
 			self.blocksize = uint4(blockchain)
+		else:
+			self.continueParsing = False
+			return
 		
 		if self.hasLength(blockchain, self.blocksize):
 			self.setHeader(blockchain)
@@ -45,9 +48,7 @@ class Block:
 		return self.continueParsing
 
 	def getBlocksize(self):
-		if self.blocksize != '':
-			return self.blockdize
-		return 0
+		return self.blocksize
 
 	def hasLength(self, blockchain, size):
 		curPos = blockchain.tell()


### PR DESCRIPTION
When a block file has been read until the end, hasLength(blockchain, 8) evaluates to false correctly, but hasLength(blockchain, self.blocksize) evaluates to true because self.blocksize is initialized with 0. Hence, the block reader will attempt to read beyond the end of the file.

Fix attached.
